### PR TITLE
removed "fmt" in import

### DIFF
--- a/zeptomail.go
+++ b/zeptomail.go
@@ -3,7 +3,6 @@ package zeptomail
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 


### PR DESCRIPTION
it is done to fix the compile time error:
" `fmt` imported and not used "